### PR TITLE
README.md updated with extra commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ composer install
 
 Install Drupal using a simple sqlite database.
 ```
+cd web
 drush site-install config_installer
 ```
 


### PR DESCRIPTION
Before running `drush site-install config_installer` user needs to switch to the `web` folder where Drupal root resides. Without the directory switch the following message is displayed: 
```
$ drush site-install config_installer
Command site-install needs a higher bootstrap level to run - you will need to invoke drush from a more       [error]
functional Drupal environment to run this command.
The drush command 'site-install config_installer' could not be executed.
```